### PR TITLE
Feature - Layout padding

### DIFF
--- a/code/DataComponent.tsx
+++ b/code/DataComponent.tsx
@@ -95,6 +95,15 @@ export function DataComponent(props: DataComponentProps) {
         if (!connectedListItem) {
             return []
         }
+        const { props: connectedListItemProps } = connectedListItem as any
+        const listItemWidth = getListItemWidth(
+            direction,
+            rest.width,
+            columns,
+            horizontalGap,
+            connectedListItemProps.width
+        )
+
         return results.map((result, index) => {
             const listItemStyles = getListItemStyle(
                 direction,
@@ -104,14 +113,6 @@ export function DataComponent(props: DataComponentProps) {
                 columns,
                 index,
                 results.length
-            )
-            const { props: connectedListItemProps } = connectedListItem as any
-            const listItemWidth = getListItemWidth(
-                direction,
-                rest.width,
-                columns,
-                horizontalGap,
-                connectedListItemProps.width
             )
 
             const resultData = Object.keys(result).reduce((acc, key) => {

--- a/code/DataComponent.tsx
+++ b/code/DataComponent.tsx
@@ -42,6 +42,12 @@ export function DataComponent(props: DataComponentProps) {
         sortKey,
         columns,
         gap,
+        paddingPerSide,
+        padding,
+        paddingTop,
+        paddingRight,
+        paddingBottom,
+        paddingLeft,
         wrap,
         verticalAlignment,
         verticalDistribution,
@@ -239,6 +245,20 @@ export function DataComponent(props: DataComponentProps) {
         onItemTap,
     ])
 
+    const containerPadding = React.useMemo(() => {
+        if (paddingPerSide) {
+            return `${paddingTop}px ${paddingRight}px ${paddingBottom}px ${paddingLeft}px`
+        }
+        return `${padding}px`
+    }, [
+        paddingPerSide,
+        padding,
+        paddingTop,
+        paddingRight,
+        paddingBottom,
+        paddingLeft,
+    ])
+
     if (errorMessage) {
         return (
             <Placeholder
@@ -340,6 +360,7 @@ export function DataComponent(props: DataComponentProps) {
         columns,
         verticalAlignment,
         verticalDistribution,
+        padding: containerPadding,
     })
 
     if (!isScrollEnabled) {
@@ -450,6 +471,20 @@ addPropertyControls(DataComponent, {
             (props.columns > 1 ||
                 isVerticalGapControlledByContainer(props.verticalDistribution))
     ),
+    padding: {
+        title: indentPropertyControlTitle("Padding"),
+        type: ControlType.FusedNumber,
+        toggleKey: "paddingPerSide",
+        toggleTitles: ["Padding", "Padding per side"],
+        valueKeys: [
+            "paddingTop",
+            "paddingRight",
+            "paddingBottom",
+            "paddingLeft",
+        ],
+        valueLabels: ["T", "R", "B", "L"],
+        min: 0,
+    },
     horizontalGap: gapControl<DataComponentProps>(
         indentPropertyControlTitle("Gap (↔)"),
         (props) => !(props.direction === "vertical" && props.columns > 1)

--- a/code/DataComponent.tsx
+++ b/code/DataComponent.tsx
@@ -205,7 +205,7 @@ export function DataComponent(props: DataComponentProps) {
                     {React.cloneElement(
                         connectedHoverListItem as React.ReactElement,
                         {
-                            key: result.id,
+                            key: `hover-${result.id}`,
                             width: "100%",
                             style: {
                                 ...adjustedListItemStyles,

--- a/code/DataComponent.tsx
+++ b/code/DataComponent.tsx
@@ -150,6 +150,9 @@ export function DataComponent(props: DataComponentProps) {
                 props: connectedHoverListItemProps,
             } = connectedHoverListItem as any
 
+            // When we're using a hover state, the right margin should be applied to the wrapper, and not to the list item itself
+            const { marginRight, ...adjustedListItemStyles } = listItemStyles
+
             return (
                 <Frame
                     key={`wrapper-${result.id}`}
@@ -160,9 +163,10 @@ export function DataComponent(props: DataComponentProps) {
                     initial={"default"}
                     style={{
                         position: "relative",
+                        marginRight,
                         // If we're rendering with a hover state, the margin must be applied to the container instead of the list item itself
-                        marginBottom: listItemStyles.marginBottom
-                            ? listItemStyles.marginBottom
+                        marginBottom: adjustedListItemStyles.marginBottom
+                            ? adjustedListItemStyles.marginBottom
                             : 0,
                     }}
                 >
@@ -170,9 +174,10 @@ export function DataComponent(props: DataComponentProps) {
                         connectedListItem as React.ReactElement,
                         {
                             key: result.id,
-                            width: listItemWidth,
+                            // When we have a hover state, the list item can just span 100% of the width. The hover wrapper has the correct calculated width
+                            width: "100%",
                             style: {
-                                ...listItemStyles,
+                                ...adjustedListItemStyles,
                                 ...connectedListItemProps.style,
                             },
                             ...resultData,
@@ -195,9 +200,9 @@ export function DataComponent(props: DataComponentProps) {
                         connectedHoverListItem as React.ReactElement,
                         {
                             key: result.id,
-                            width: listItemWidth,
+                            width: "100%",
                             style: {
-                                ...listItemStyles,
+                                ...adjustedListItemStyles,
                                 ...connectedHoverListItemProps.style,
                             },
                             ...resultData,

--- a/code/utils/layout.tsx
+++ b/code/utils/layout.tsx
@@ -1,10 +1,5 @@
 import * as React from "react"
-import {
-    FlexDirection,
-    FlexWrap,
-    FlexAlignment,
-    FlexDistribution,
-} from "./types"
+import { FlexDirection, FlexDistribution, LayoutConfig } from "./types"
 
 const containerStyle: React.CSSProperties = {
     display: "flex",
@@ -73,25 +68,9 @@ export function getListItemWidth(
 
 export function renderContainer(
     resultItems: React.ReactElement[],
-    layoutConfig: {
-        width: number
-        height: number
-        direction: FlexDirection
-        wrap: FlexWrap
-        columns: number
-        verticalAlignment: FlexAlignment
-        verticalDistribution: FlexDistribution
-    }
+    layoutConfig: LayoutConfig
 ) {
-    return (
-        <div
-            style={{
-                ...getContainerStyle(layoutConfig),
-            }}
-        >
-            {resultItems}
-        </div>
-    )
+    return <div style={getContainerStyle(layoutConfig)}>{resultItems}</div>
 }
 
 export function getContainerStyle({
@@ -102,19 +81,13 @@ export function getContainerStyle({
     columns,
     verticalAlignment,
     verticalDistribution,
-}: {
-    width: number
-    height: number
-    direction: FlexDirection
-    wrap: FlexWrap
-    columns: number
-    verticalAlignment: FlexAlignment
-    verticalDistribution: FlexDistribution
-}) {
+    padding,
+}: LayoutConfig) {
     let styles: React.CSSProperties = {
         ...containerStyle,
         width: "100%",
         height: direction === "vertical" ? "100%" : height,
+        padding,
     }
 
     if (direction === "vertical") {

--- a/code/utils/types.ts
+++ b/code/utils/types.ts
@@ -9,6 +9,16 @@ export type FlexDistribution =
     | "space-between"
     | "space-around"
     | "space-evenly"
+export interface LayoutConfig {
+    width: number
+    height: number
+    direction: FlexDirection
+    wrap: FlexWrap
+    columns: number
+    verticalAlignment: FlexAlignment
+    verticalDistribution: FlexDistribution
+    padding: string
+}
 
 // Component Props
 export type ComponentMode = "default" | "help" | "debug"
@@ -65,6 +75,12 @@ export interface DataComponentProps {
     verticalDistribution: FlexDistribution
     columns: number
     gap: number
+    paddingPerSide: boolean
+    padding: number
+    paddingTop: number
+    paddingRight: number
+    paddingBottom: number
+    paddingLeft: number
     wrap: FlexWrap
     horizontalGap: number
     verticalGap: number


### PR DESCRIPTION
This PR introduces support for adding padding to the container that wraps the list items. Thank you to [Richy in Discord](https://discord.com/channels/341919693348536320/772820672392986634/775073765720981525) for suggesting this!

I also fixed a few bugs/tweaked some things:
- The width of a list item is now only calculated once, prior to this it would be calculated for every item
- Multiple columns were not working when a hover state was being used
- Fixed a duplicate key error when using a hover state