### PR TITLE
Fix - Layout Issues

### DIFF
--- a/code/DataComponent.tsx
+++ b/code/DataComponent.tsx
@@ -31,7 +31,6 @@ export function DataComponent(props: DataComponentProps) {
         httpAuthorizationHeader,
         httpHeaders,
         listItem,
-        hoverListItem,
         loadingState,
         loadingDelay,
         emptyState,
@@ -91,9 +90,6 @@ export function DataComponent(props: DataComponentProps) {
             unparsedHeaders: httpHeaders,
         }
     )
-    const [connectedHoverListItem] = useConnectedComponentInstance(
-        hoverListItem
-    )
     const [connectedListItem] = useConnectedComponentInstance(listItem)
     const [connectedLoadingState] = useConnectedComponentInstance(loadingState)
     const [connectedEmptyState] = useConnectedComponentInstance(emptyState)
@@ -130,106 +126,23 @@ export function DataComponent(props: DataComponentProps) {
                 return acc
             }, {})
 
-            if (!connectedHoverListItem) {
-                return React.cloneElement(
-                    connectedListItem as React.ReactElement,
-                    {
-                        key: result.id,
-                        width: listItemWidth,
-                        style: {
-                            position: "relative",
-                            ...listItemStyles,
-                            ...connectedListItem.props.style,
-                            width: listItemWidth,
-                            height: connectedListItem.props.height,
-                        },
-                        ...resultData,
-                        index,
-                        id: `${result.id}—${index}`,
-                        onTap() {
-                            onItemTap(result)
-                        },
-                    }
-                )
-            }
-
-            const {
-                props: connectedHoverListItemProps,
-            } = connectedHoverListItem as any
-
-            // When we're using a hover state, the right margin should be applied to the wrapper, and not to the list item itself
-            const { marginRight, ...adjustedListItemStyles } = listItemStyles
-
-            return (
-                <Frame
-                    key={`wrapper-${result.id}`}
-                    width={listItemWidth}
-                    height={connectedListItem.props.height}
-                    background={"transparent"}
-                    whileHover={"hover"}
-                    initial={"default"}
-                    style={{
-                        position: "relative",
-                        marginRight,
-                        // If we're rendering with a hover state, the margin must be applied to the container instead of the list item itself
-                        marginBottom: adjustedListItemStyles.marginBottom
-                            ? adjustedListItemStyles.marginBottom
-                            : 0,
-                    }}
-                >
-                    {React.cloneElement(
-                        connectedListItem as React.ReactElement,
-                        {
-                            key: result.id,
-                            // When we have a hover state, the list item can just span 100% of the width. The hover wrapper has the correct calculated width
-                            width: "100%",
-                            style: {
-                                ...adjustedListItemStyles,
-                                ...connectedListItem.props.style,
-                            },
-                            ...resultData,
-                            index,
-                            id: `${result.id}—${index}`,
-                            variants: {
-                                hover: {
-                                    visibility: "hidden",
-                                },
-                                default: {
-                                    visibility: "visible",
-                                },
-                            },
-                            onTap() {
-                                onItemTap(result)
-                            },
-                        }
-                    )}
-                    {React.cloneElement(
-                        connectedHoverListItem as React.ReactElement,
-                        {
-                            key: `hover-${result.id}`,
-                            width: "100%",
-                            style: {
-                                ...adjustedListItemStyles,
-                                ...connectedHoverListItemProps.style,
-                            },
-                            ...resultData,
-                            index,
-                            id: `${result.id}—${index}-hover`,
-                            variants: {
-                                hover: {
-                                    visibility: "visible",
-                                },
-                                default: {
-                                    visibility: "hidden",
-                                },
-                            },
-                            onTap() {
-                                onItemTap(result)
-                            },
-                        }
-                    )}
-                </Frame>
-            )
+            return React.cloneElement(connectedListItem as React.ReactElement, {
+                key: result.id,
+                width: listItemWidth,
+                style: {
+                    position: "relative",
+                    ...listItemStyles,
+                    ...connectedListItem.props.style,
+                    width: listItemWidth,
+                    height: connectedListItem.props.height,
+                },
+                ...resultData,
+                index,
+                id: `${result.id}—${index}`,
+                onTap() {
+                    onItemTap(result)
+                },
+            })
         })
     }, [
         results,
@@ -238,7 +151,6 @@ export function DataComponent(props: DataComponentProps) {
         horizontalGap,
         verticalGap,
         connectedListItem,
-        connectedHoverListItem,
         shouldSort,
         sortDirection,
         sortKey,
@@ -277,7 +189,6 @@ export function DataComponent(props: DataComponentProps) {
                 mode={"help"}
                 results={results}
                 isListItemConnected={!!connectedListItem}
-                isHoverListItemConnected={!!connectedHoverListItem}
                 isEmptyStateConnected={!!connectedEmptyState}
                 isLoadingStateConnected={!!connectedLoadingState}
             />
@@ -291,7 +202,6 @@ export function DataComponent(props: DataComponentProps) {
                 mode={"debug"}
                 results={results}
                 isListItemConnected={!!connectedListItem}
-                isHoverListItemConnected={!!connectedHoverListItem}
                 isEmptyStateConnected={!!connectedEmptyState}
                 isLoadingStateConnected={!!connectedLoadingState}
             />
@@ -304,7 +214,6 @@ export function DataComponent(props: DataComponentProps) {
                 {...props}
                 mode={"connect-list-item"}
                 isListItemConnected={!!connectedListItem}
-                isHoverListItemConnected={!!connectedHoverListItem}
                 isEmptyStateConnected={!!connectedEmptyState}
                 isLoadingStateConnected={!!connectedLoadingState}
             />
@@ -317,7 +226,6 @@ export function DataComponent(props: DataComponentProps) {
                 {...props}
                 mode={"api-url"}
                 isListItemConnected={!!connectedListItem}
-                isHoverListItemConnected={!!connectedHoverListItem}
                 isEmptyStateConnected={!!connectedEmptyState}
                 isLoadingStateConnected={!!connectedLoadingState}
             />
@@ -339,7 +247,6 @@ export function DataComponent(props: DataComponentProps) {
                 {...props}
                 mode={"loading"}
                 isListItemConnected={!!connectedListItem}
-                isHoverListItemConnected={!!connectedHoverListItem}
                 isEmptyStateConnected={!!connectedEmptyState}
                 isLoadingStateConnected={!!connectedLoadingState}
             />
@@ -543,10 +450,6 @@ addPropertyControls(DataComponent, {
     },
     listItem: {
         title: "List Item",
-        type: ControlType.ComponentInstance,
-    },
-    hoverListItem: {
-        title: "Hover List Item",
         type: ControlType.ComponentInstance,
     },
     loadingState: {

--- a/code/hooks/useConnectedSmartComponent.ts
+++ b/code/hooks/useConnectedSmartComponent.ts
@@ -1,0 +1,45 @@
+import * as React from "react"
+
+export function useConnectedSmartComponent(
+    listItem: React.ReactNode
+): [React.ReactElement | null, React.ReactElement | null] {
+    const [connectedContainer, connectedComponent] = React.useMemo<
+        [React.ReactElement | null, React.ReactElement | null]
+    >(() => {
+        const listItemAsArray = React.Children.toArray(listItem)
+        if (!listItemAsArray || !listItemAsArray.length) {
+            return [null, null]
+        }
+
+        const container = listItemAsArray[0] as React.ReactElement
+        const containerKey = container.key as string | undefined
+
+        const containerChildren = React.Children.toArray(
+            container.props.children
+        )
+
+        /**
+         * Legacy design components do not have a component identifier.
+         * They also do not have a key, and if they do, it is not suffixed
+         * with -container. In this case, we return the component directly,
+         * as we can spread the props of the data directly across it,
+         * and we don't need to deal with component containers
+         */
+        if (
+            !container.props.componentIdentifier &&
+            (!containerKey || !containerKey.endsWith("-container"))
+        ) {
+            return [null, container]
+        }
+
+        if (!containerChildren || !containerChildren.length) {
+            return [null, container]
+        }
+
+        const underlyingComponent = containerChildren[0]
+
+        return [container, underlyingComponent]
+    }, [listItem])
+
+    return [connectedContainer, connectedComponent]
+}

--- a/code/utils/types.ts
+++ b/code/utils/types.ts
@@ -85,7 +85,6 @@ export interface DataComponentProps {
     horizontalGap: number
     verticalGap: number
     listItem?: React.ReactNode
-    hoverListItem?: React.ReactNode
     loadingState?: React.ReactNode
     loadingDelay: number
     emptyState?: React.ReactNode


### PR DESCRIPTION
This PR fixes a number of layout issues that occurred due to some internals in Framer changing, where components would not render at the correct size or would not show the populated data as expected. It aims to keep backwards compatibility with Framer Desktop (now legacy), and also support the various different ways components can be used and viewed.

The underlying problem was that some components now get an intermediate size wrapper which needs to be cloned and sized appropriately. For this, I introduced a new hook called `useConnectedSmartComponent` which returns both the container that needs to be sized and the connected component itself which will have data from your source injected. When connecting legacy design components on Framer Desktop, the container is not there, so the connected item will have both the sizing properties and data properties set.

This PR also removes support for the Hover List Item property control as Framer now supports this natively and I haven't seen much usage of the feature. Big thanks to @addisonschultz for already starting this work in https://github.com/iKettles/framer-data-component.framerfx/pull/14